### PR TITLE
修复校验properties时，检查KEY长度时，错判断distinct_id长度

### DIFF
--- a/SensorsAnalytics.php
+++ b/SensorsAnalytics.php
@@ -70,7 +70,7 @@ class SensorsAnalytics {
                 if (!is_string($key)) {
                     throw new SensorsAnalyticsIllegalDataException("property key must be a str. [key=$key]");
                 }
-                if (strlen($data['distinct_id']) > 255) {
+                if (strlen($key) > 255) {
                     throw new SensorsAnalyticsIllegalDataException("the max length of property key is 256. [key=$key]");
                 }
 


### PR DESCRIPTION
	LINE: https://github.com/sensorsdata/sa-sdk-php/blob/master/SensorsAnalytics.php#L73

Signed-off-by: monkey <monkey92t@gmail.com>