### PR TITLE
动态创建属性的方式已被弃用，应先定义

### DIFF
--- a/SensorsAnalytics.php
+++ b/SensorsAnalytics.php
@@ -1065,6 +1065,7 @@ class BatchConsumer extends AbstractConsumer {
     private $_max_size;
     private $_url_prefix;
     private $_request_timeout;
+    private $_response_info;
     private $file_handler;
 
     /**


### PR DESCRIPTION
Creation of dynamic property BatchConsumer::$_response_info is deprecated

同样的问题见 #14 